### PR TITLE
Text colors conflict with background when using a dark theme

### DIFF
--- a/res/values-v11/styles.xml
+++ b/res/values-v11/styles.xml
@@ -10,14 +10,12 @@
         <item name="android:textSize">@dimen/title_textsize</item>
         <item name="android:textStyle">bold</item>
         <item name="android:textIsSelectable">true</item>
-        <item name="android:textColor">@android:color/black</item>
     </style>
     
     <style name="License.Name">
         <item name="android:textSize">@dimen/name_textsize</item>
         <item name="android:padding">@dimen/text_padding</item>
         <item name="android:textIsSelectable">true</item>
-        <item name="android:textColor">@android:color/black</item>
     </style>
     
     <style name="License.License">


### PR DESCRIPTION
When applying a dark theme to the library, the background is dark, and the black text of the view shows up poorly.

This allow the default font colors from the applied theme to be used since the applied theme's default background is being used.

Before:
![screen shot 2014-01-17 at 5 49 20 pm](https://f.cloud.github.com/assets/1709517/1945637/0b4aee2e-7fd3-11e3-8c81-434370752529.png)

After:
![screen shot 2014-01-17 at 5 47 11 pm](https://f.cloud.github.com/assets/1709517/1945639/11d7f0b6-7fd3-11e3-9345-2473bbf90663.png)
